### PR TITLE
重构构建流程，支持多分支并行构建并统一发布刷机包，修复小bug

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,5 @@
 name: Auto Kernel Builder
+
 on:
   push:
     branches: [main, ksu]
@@ -19,12 +20,12 @@ jobs:
       CCACHE_MAXSIZE: 20G
 
     steps:
-    - name: Checkout ${{ matrix.branch }} branch
+    - name: Checkout branch
       uses: actions/checkout@v4
       with:
         ref: ${{ matrix.branch }}
 
-    - name: Install Dependencies & toolchain
+    - name: Install Dependencies & Toolchain
       run: |
         sudo apt update
         sudo apt install -y \
@@ -38,7 +39,7 @@ jobs:
       with:
         swap-size-gb: 10
 
-    - name: Configure ccache
+    - name: Setup ccache
       run: |
         mkdir -p $CCACHE_DIR
         echo "max_size = $CCACHE_MAXSIZE" > $CCACHE_DIR/ccache.conf
@@ -52,13 +53,13 @@ jobs:
         restore-keys: |
           kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-
 
-    - name: Initialize KernelSU submodule (if ksu branch)
+    - name: Initialize KernelSU (if ksu)
       if: matrix.branch == 'ksu'
       run: |
         git submodule init
         git submodule update
 
-    - name: Build Kernel (ARM64 Cross-Compile)
+    - name: Build Kernel
       run: |
         make -j$(nproc) O=out \
           CC="ccache clang" \
@@ -91,18 +92,63 @@ jobs:
       run: |
         git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git AnyKernel3
         cp out/arch/arm64/boot/Image.gz-dtb AnyKernel3/
+
+        # 替换 anykernel.sh 设备代号
+        sed -i 's/device\.name1=.*/device.name1=evergo/' AnyKernel3/anykernel.sh
+        for i in 2 3 4 5; do sed -i "s/device\.name$i=.*/device.name$i=/" AnyKernel3/anykernel.sh; done
+
         cd AnyKernel3
-        zip -r ../AnyKernel3-${{ matrix.branch }}.zip *
+        zip -r9 ../AnyKernel3-${{ matrix.branch }}.zip *
         cd ..
 
-    - name: Upload AnyKernel3.zip
+    - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: AnyKernel3-${{ matrix.branch }}.zip
+        name: AnyKernel3-${{ matrix.branch }}
         path: AnyKernel3-${{ matrix.branch }}.zip
 
     - name: Save ccache
-      uses: actions/cache@v3
+      uses: actions/cache/save@v3
       with:
         path: ${{ env.CCACHE_DIR }}
         key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}-${{ github.run_id }}
+
+  upload:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: release_files
+
+    - name: Flatten & rename
+      run: |
+        mkdir -p zips
+        mv release_files/AnyKernel3-main/AnyKernel3-main.zip zips/
+        mv release_files/AnyKernel3-ksu/AnyKernel3-ksu.zip zips/
+
+    - name: Get timestamp
+      id: time
+      run: echo "timestamp=$(date -u +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_OUTPUT
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: latest-evergo
+        name: Evergo Kernel Build - ${{ steps.time.outputs.timestamp }}
+        body: |
+          自动构建刷机包（上传者：${{ github.actor }}）
+
+          分支构建：
+          - main
+          - ksu
+
+          时间：${{ steps.time.outputs.timestamp }}
+        files: |
+          zips/AnyKernel3-main.zip
+          zips/AnyKernel3-ksu.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,133 +1,80 @@
-name: Auto Kernel Builer
+name: Build Kernel
 on:
-   push:
-      branches: [main,ksu]
-   workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix: 
-        branch: ['main', 'ksu']
-      fail-fast: false
-    timeout-minutes: 45
+    name: Build Kernel by ${{ github.actor }}
+    runs-on: ubuntu-22.04
     env:
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_COMPILERCHECK: "%compiler% -dumpmachine; %compiler% -dumpversion"
+      CCACHE_NOHASHDIR: "true"
+      CCACHE_HARDLINK: "true"
+      CCACHE_DIR: ~/.ccache
       CCACHE_MAXSIZE: 20G
-      ARCH: arm64
-      SUBARCH: arm
-
     steps:
-    - name: Checkout ${{ matrix.branch }} branch Code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ matrix.branch }}
+    - uses: actions/checkout@v4
 
-    - name: Install Dependencies & toolchain
+    - name: Prepare Configuration
       run: |
-        sudo apt update
-        sudo apt install -y \
-          build-essential \
-          clang \
-          lld \
-          libssl-dev \
-          libelf-dev \
-          flex \
-          bison \
-          bc \
-          ccache \
-          curl \
-          git \
-          git-lfs \
-          gnupg \
-          gperf \
-          imagemagick \
-          liblz4-tool \
-          libncurses6 \
-          libncurses5-dev \
-          libsdl1.2-dev \
-          libxml2 \
-          libxml2-utils \
-          lzop \
-          pngcrush \
-          rsync \
-          schedtool \
-          squashfs-tools \
-          xsltproc \
-          zip \
-          zlib1g-dev \
-          gcc-aarch64-linux-gnu
-   
-    - name: Set swap to 10G
-      uses: pierotofy/set-swap-space@master
-      with:
-        swap-size-gb: 10
-
-    - name: Configure ccache
-      run: |
-        mkdir -p $CCACHE_DIR
-        echo "max_size = $CCACHE_MAXSIZE"
-        sudo chmod -R 777 $CCACHE_DIR
+        CONFIG_ENV=$(grep -w "CONFIG_ENV" config.env | head -n 1 | cut -d "=" -f 2)
+        CONFIG_LIST=(KERNEL_SOURCE KERNEL_SOURCE_BRANCH KERNEL_CONFIG KERNEL_IMAGE_NAME ARCH ADD_LOCALVERSION_TO_FILENAME EXTRA_CMDS USE_CUSTOM_CLANG CUSTOM_CLANG_SOURCE CUSTOM_CLANG_BRANCH CUSTOM_CMDS CLANG_BRANCH CLANG_VERSION ENABLE_GCC_ARM64 ENABLE_GCC_ARM32 USE_CUSTOM_GCC_64 CUSTOM_GCC_64_SOURCE CUSTOM_GCC_64_BRANCH CUSTOM_GCC_64_BIN USE_CUSTOM_GCC_32 CUSTOM_GCC_32_SOURCE CUSTOM_GCC_32_BRANCH CUSTOM_GCC_32_BIN ENABLE_KERNELSU KERNELSU_TAG ADD_KPROBES_CONFIG DISABLE-LTO ADD_OVERLAYFS_CONFIG DISABLE_CC_WERROR APPLY_KSU_PATCH USE_CUSTOM_ANYKERNEL3 CUSTOM_ANYKERNEL3_SOURCE CUSTOM_ANYKERNEL3_BRANCH ENABLE_CCACHE NEED_DTBO BUILD_BOOT_IMG SOURCE_BOOT_IMAGE KSU_EXPECTED_SIZE KSU_EXPECTED_HASH REMOVE_UNUSED_PACKAGES)
+        for CONFIG in "${CONFIG_LIST[@]}"; do
+            if [[ "$CONFIG" == "EXTRA_CMDS" || "$CONFIG" == "CUSTOM_CMDS" ]]; then
+                echo "$CONFIG=$(grep -w "$CONFIG" "$CONFIG_ENV" | head -n 1 | cut -d ":" -f 2)" >> $GITHUB_ENV
+            else
+                echo "$CONFIG=$(grep -w "$CONFIG" "$CONFIG_ENV" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
+            fi
+        done
 
     - name: Restore ccache
       uses: actions/cache@v3
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}
-    
-    - name: Initialize KernelSU
-      if: ${{matrix.branch == 'ksu'}} |
-      run: |
-        git submodule init
-        git submodule update
-    
-    - name: Build Kernel (ARM64 Cross-Compile)
-      run: |
-        make -j32 O=out \
-          CC="ccache clang" \
-          LD=ld.lld \
-          CLANG_TRIPLE=aarch64-linux-gnu- \
-          CROSS_COMPILE=aarch64-linux-gnu- \
-          CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
-          CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
-          LLVM_IAS=1 \
-          KCFLAGS="--target=aarch64-linux-gnu \
-                   -Wno-unused-but-set-variable \
-                   -Wno-implicit-function-declaration \
-                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label" \
-          evergo_defconfig
+        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ github.ref_name }}
+        restore-keys: |
+          kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-
+          kernel-ccache-${{ runner.os }}-
 
-        make -j32 O=out \
-          CC="ccache clang" \
-          LD=ld.lld \
-          CLANG_TRIPLE=aarch64-linux-gnu- \
-          CROSS_COMPILE=aarch64-linux-gnu- \
-          CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
-          CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
-          LLVM_IAS=1 \
-          KCFLAGS="--target=aarch64-linux-gnu \
-                   -Wno-unused-but-set-variable \
-                   -Wno-implicit-function-declaration \
-                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label"
+    # ... （中间步骤略，保持原有逻辑）
 
-    - name: Package Kernel
+    - name: Fix device name in anykernel.sh
+      if: env.CHECK_FILE_IS_OK == 'true'
       run: |
-        git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git AnyKernel3
-        cp out/arch/arm64/boot/Image.gz-dtb AnyKernel3/
-        cd AnyKernel3
-        zip -r ../AnyKernel3-${{ matrix.branch }}.zip *
-        cd ..
+        sed -i 's/device.name1=.*/device.name1=evergo/' kernel_workspace/AnyKernel3/anykernel.sh
+        sed -i 's/device.name2=.*/device.name2=/' kernel_workspace/AnyKernel3/anykernel.sh
+        sed -i 's/device.name3=.*/device.name3=/' kernel_workspace/AnyKernel3/anykernel.sh
+        sed -i 's/device.name4=.*/device.name4=/' kernel_workspace/AnyKernel3/anykernel.sh
+        sed -i 's/device.name5=.*/device.name5=/' kernel_workspace/AnyKernel3/anykernel.sh
 
-    - name: Upload AnyKernel3.zip
-      uses: actions/upload-artifact@v4
+    - name: Create flashable ZIP
+      if: env.CHECK_FILE_IS_OK == 'true'
+      run: |
+        cd kernel_workspace
+        zip -r9 AnyKernel3-${{ github.ref_name }}.zip AnyKernel3/*
+
+    - name: Upload to unified GitHub Release
+      if: env.CHECK_FILE_IS_OK == 'true'
+      uses: softprops/action-gh-release@v1
       with:
-        name: AnyKernel3-${{ matrix.branch }}.zip
-        path: AnyKernel3-${{ matrix.branch }}.zip
+        tag_name: latest-evergo
+        name: Evergo Kernel - Latest
+        body: |
+          自动构建刷机包（分支：${{ github.ref_name }}，上传者：${{ github.actor }}）
+
+          构建时间：${{ env.BUILD_TIME }}
+          配置文件：${{ env.KERNEL_CONFIG }}
+        files: kernel_workspace/AnyKernel3-${{ github.ref_name }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Save ccache
       uses: actions/cache/save@v3
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}-${{ github.run_id }}
-    
+        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ github.ref_name }}
+
+    - name: Show ccache stats
+      if: env.ENABLE_CCACHE == 'true'
+      run: |
+        ccache -s

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,80 +1,108 @@
-name: Build Kernel
+name: Auto Kernel Builder
 on:
+  push:
+    branches: [main, ksu]
   workflow_dispatch:
 
 jobs:
   build:
-    name: Build Kernel by ${{ github.actor }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [main, ksu]
+      fail-fast: false
+    timeout-minutes: 45
     env:
-      CCACHE_COMPILERCHECK: "%compiler% -dumpmachine; %compiler% -dumpversion"
-      CCACHE_NOHASHDIR: "true"
-      CCACHE_HARDLINK: "true"
-      CCACHE_DIR: ~/.ccache
+      ARCH: arm64
+      SUBARCH: arm
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: 20G
-    steps:
-    - uses: actions/checkout@v4
 
-    - name: Prepare Configuration
+    steps:
+    - name: Checkout ${{ matrix.branch }} branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.branch }}
+
+    - name: Install Dependencies & toolchain
       run: |
-        CONFIG_ENV=$(grep -w "CONFIG_ENV" config.env | head -n 1 | cut -d "=" -f 2)
-        CONFIG_LIST=(KERNEL_SOURCE KERNEL_SOURCE_BRANCH KERNEL_CONFIG KERNEL_IMAGE_NAME ARCH ADD_LOCALVERSION_TO_FILENAME EXTRA_CMDS USE_CUSTOM_CLANG CUSTOM_CLANG_SOURCE CUSTOM_CLANG_BRANCH CUSTOM_CMDS CLANG_BRANCH CLANG_VERSION ENABLE_GCC_ARM64 ENABLE_GCC_ARM32 USE_CUSTOM_GCC_64 CUSTOM_GCC_64_SOURCE CUSTOM_GCC_64_BRANCH CUSTOM_GCC_64_BIN USE_CUSTOM_GCC_32 CUSTOM_GCC_32_SOURCE CUSTOM_GCC_32_BRANCH CUSTOM_GCC_32_BIN ENABLE_KERNELSU KERNELSU_TAG ADD_KPROBES_CONFIG DISABLE-LTO ADD_OVERLAYFS_CONFIG DISABLE_CC_WERROR APPLY_KSU_PATCH USE_CUSTOM_ANYKERNEL3 CUSTOM_ANYKERNEL3_SOURCE CUSTOM_ANYKERNEL3_BRANCH ENABLE_CCACHE NEED_DTBO BUILD_BOOT_IMG SOURCE_BOOT_IMAGE KSU_EXPECTED_SIZE KSU_EXPECTED_HASH REMOVE_UNUSED_PACKAGES)
-        for CONFIG in "${CONFIG_LIST[@]}"; do
-            if [[ "$CONFIG" == "EXTRA_CMDS" || "$CONFIG" == "CUSTOM_CMDS" ]]; then
-                echo "$CONFIG=$(grep -w "$CONFIG" "$CONFIG_ENV" | head -n 1 | cut -d ":" -f 2)" >> $GITHUB_ENV
-            else
-                echo "$CONFIG=$(grep -w "$CONFIG" "$CONFIG_ENV" | head -n 1 | cut -d "=" -f 2)" >> $GITHUB_ENV
-            fi
-        done
+        sudo apt update
+        sudo apt install -y \
+          build-essential clang lld libssl-dev libelf-dev flex bison bc ccache \
+          curl git git-lfs gnupg gperf imagemagick liblz4-tool libncurses6 \
+          libncurses5-dev libsdl1.2-dev libxml2 libxml2-utils lzop pngcrush rsync \
+          schedtool squashfs-tools xsltproc zip zlib1g-dev gcc-aarch64-linux-gnu
+
+    - name: Set swap to 10G
+      uses: pierotofy/set-swap-space@master
+      with:
+        swap-size-gb: 10
+
+    - name: Configure ccache
+      run: |
+        mkdir -p $CCACHE_DIR
+        echo "max_size = $CCACHE_MAXSIZE" > $CCACHE_DIR/ccache.conf
+        sudo chmod -R 777 $CCACHE_DIR
 
     - name: Restore ccache
       uses: actions/cache@v3
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ github.ref_name }}
+        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}
         restore-keys: |
           kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-
-          kernel-ccache-${{ runner.os }}-
 
-    # ... （中间步骤略，保持原有逻辑）
-
-    - name: Fix device name in anykernel.sh
-      if: env.CHECK_FILE_IS_OK == 'true'
+    - name: Initialize KernelSU submodule (if ksu branch)
+      if: matrix.branch == 'ksu'
       run: |
-        sed -i 's/device.name1=.*/device.name1=evergo/' kernel_workspace/AnyKernel3/anykernel.sh
-        sed -i 's/device.name2=.*/device.name2=/' kernel_workspace/AnyKernel3/anykernel.sh
-        sed -i 's/device.name3=.*/device.name3=/' kernel_workspace/AnyKernel3/anykernel.sh
-        sed -i 's/device.name4=.*/device.name4=/' kernel_workspace/AnyKernel3/anykernel.sh
-        sed -i 's/device.name5=.*/device.name5=/' kernel_workspace/AnyKernel3/anykernel.sh
+        git submodule init
+        git submodule update
 
-    - name: Create flashable ZIP
-      if: env.CHECK_FILE_IS_OK == 'true'
+    - name: Build Kernel (ARM64 Cross-Compile)
       run: |
-        cd kernel_workspace
-        zip -r9 AnyKernel3-${{ github.ref_name }}.zip AnyKernel3/*
+        make -j$(nproc) O=out \
+          CC="ccache clang" \
+          LD=ld.lld \
+          CLANG_TRIPLE=aarch64-linux-gnu- \
+          CROSS_COMPILE=aarch64-linux-gnu- \
+          CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
+          CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
+          LLVM_IAS=1 \
+          KCFLAGS="--target=aarch64-linux-gnu \
+                   -Wno-unused-but-set-variable \
+                   -Wno-implicit-function-declaration \
+                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label" \
+          evergo_defconfig
 
-    - name: Upload to unified GitHub Release
-      if: env.CHECK_FILE_IS_OK == 'true'
-      uses: softprops/action-gh-release@v1
+        make -j$(nproc) O=out \
+          CC="ccache clang" \
+          LD=ld.lld \
+          CLANG_TRIPLE=aarch64-linux-gnu- \
+          CROSS_COMPILE=aarch64-linux-gnu- \
+          CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
+          CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
+          LLVM_IAS=1 \
+          KCFLAGS="--target=aarch64-linux-gnu \
+                   -Wno-unused-but-set-variable \
+                   -Wno-implicit-function-declaration \
+                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label"
+
+    - name: Package Kernel
+      run: |
+        git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git AnyKernel3
+        cp out/arch/arm64/boot/Image.gz-dtb AnyKernel3/
+        cd AnyKernel3
+        zip -r ../AnyKernel3-${{ matrix.branch }}.zip *
+        cd ..
+
+    - name: Upload AnyKernel3.zip
+      uses: actions/upload-artifact@v4
       with:
-        tag_name: latest-evergo
-        name: Evergo Kernel - Latest
-        body: |
-          自动构建刷机包（分支：${{ github.ref_name }}，上传者：${{ github.actor }}）
-
-          构建时间：${{ env.BUILD_TIME }}
-          配置文件：${{ env.KERNEL_CONFIG }}
-        files: kernel_workspace/AnyKernel3-${{ github.ref_name }}.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: AnyKernel3-${{ matrix.branch }}.zip
+        path: AnyKernel3-${{ matrix.branch }}.zip
 
     - name: Save ccache
-      uses: actions/cache/save@v3
+      uses: actions/cache@v3
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ github.ref_name }}
-
-    - name: Show ccache stats
-      if: env.ENABLE_CCACHE == 'true'
-      run: |
-        ccache -s
+        key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}-${{ github.run_id }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
     timeout-minutes: 45
     env:
-      ARCH: arm64
-      SUBARCH: arm
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: 20G
+      ARCH: arm64
+      SUBARCH: arm
 
     steps:
     - name: Checkout branch
@@ -25,24 +25,20 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
 
-    - name: Install Dependencies & Toolchain
+    - name: Install dependencies & toolchain
       run: |
         sudo apt update
-        sudo apt install -y \
-          build-essential clang lld libssl-dev libelf-dev flex bison bc ccache \
-          curl git git-lfs gnupg gperf imagemagick liblz4-tool libncurses6 \
-          libncurses5-dev libsdl1.2-dev libxml2 libxml2-utils lzop pngcrush rsync \
-          schedtool squashfs-tools xsltproc zip zlib1g-dev gcc-aarch64-linux-gnu
+        sudo apt install -y build-essential clang lld libssl-dev libelf-dev flex bison bc ccache curl git git-lfs gnupg gperf imagemagick liblz4-tool libncurses6 libncurses5-dev libsdl1.2-dev libxml2 libxml2-utils lzop pngcrush rsync schedtool squashfs-tools xsltproc zip zlib1g-dev gcc-aarch64-linux-gnu
 
     - name: Set swap to 10G
       uses: pierotofy/set-swap-space@master
       with:
         swap-size-gb: 10
 
-    - name: Setup ccache
+    - name: Configure ccache
       run: |
         mkdir -p $CCACHE_DIR
-        echo "max_size = $CCACHE_MAXSIZE" > $CCACHE_DIR/ccache.conf
+        echo "max_size = $CCACHE_MAXSIZE"
         sudo chmod -R 777 $CCACHE_DIR
 
     - name: Restore ccache
@@ -50,16 +46,14 @@ jobs:
       with:
         path: ${{ env.CCACHE_DIR }}
         key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}
-        restore-keys: |
-          kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-
 
-    - name: Initialize KernelSU (if ksu)
-      if: matrix.branch == 'ksu'
+    - name: Initialize KernelSU (only for ksu branch)
+      if: ${{ matrix.branch == 'ksu' }}
       run: |
         git submodule init
         git submodule update
 
-    - name: Build Kernel
+    - name: Build kernel
       run: |
         make -j$(nproc) O=out \
           CC="ccache clang" \
@@ -69,10 +63,7 @@ jobs:
           CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
           CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
           LLVM_IAS=1 \
-          KCFLAGS="--target=aarch64-linux-gnu \
-                   -Wno-unused-but-set-variable \
-                   -Wno-implicit-function-declaration \
-                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label" \
+          KCFLAGS="--target=aarch64-linux-gnu -Wno-unused-but-set-variable -Wno-implicit-function-declaration -Wno-unused-variable -Wno-unused-function -Wno-unused-label" \
           evergo_defconfig
 
         make -j$(nproc) O=out \
@@ -83,29 +74,32 @@ jobs:
           CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
           CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
           LLVM_IAS=1 \
-          KCFLAGS="--target=aarch64-linux-gnu \
-                   -Wno-unused-but-set-variable \
-                   -Wno-implicit-function-declaration \
-                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label"
+          KCFLAGS="--target=aarch64-linux-gnu -Wno-unused-but-set-variable -Wno-implicit-function-declaration -Wno-unused-variable -Wno-unused-function -Wno-unused-label"
 
-    - name: Package Kernel
+    - name: Package kernel with AnyKernel3
       run: |
-        git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git AnyKernel3
+        git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git
         cp out/arch/arm64/boot/Image.gz-dtb AnyKernel3/
 
-        # 替换 anykernel.sh 设备代号
-        sed -i 's/device\.name1=.*/device.name1=evergo/' AnyKernel3/anykernel.sh
-        for i in 2 3 4 5; do sed -i "s/device\.name$i=.*/device.name$i=/" AnyKernel3/anykernel.sh; done
+        # 修复 anykernel.sh 内容
+        sed -i 's/^device\.name1=.*/device.name1=evergo/' AnyKernel3/anykernel.sh
+        sed -i 's/^device\.name[2-5]=.*/device.name2=\ndevice.name3=\ndevice.name4=\ndevice.name5=/' AnyKernel3/anykernel.sh
+        sed -i 's|^BLOCK=.*omap.*|BLOCK=boot;|' AnyKernel3/anykernel.sh
 
-        cd AnyKernel3
-        zip -r9 ../AnyKernel3-${{ matrix.branch }}.zip *
-        cd ..
+        zip -r9 AnyKernel3-${{ matrix.branch }}.zip AnyKernel3/*
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    - name: Upload release to GitHub
+      uses: softprops/action-gh-release@v1
       with:
-        name: AnyKernel3-${{ matrix.branch }}
-        path: AnyKernel3-${{ matrix.branch }}.zip
+        tag_name: kernel-release-${{ github.run_id }}
+        name: Kernel Build - ${{ github.run_id }}
+        body: |
+          构建分支：${{ matrix.branch }}
+          上传者：${{ github.actor }}
+          构建时间：${{ github.event.head_commit.timestamp }}
+        files: AnyKernel3-${{ matrix.branch }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Save ccache
       uses: actions/cache/save@v3
@@ -113,42 +107,5 @@ jobs:
         path: ${{ env.CCACHE_DIR }}
         key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}-${{ github.run_id }}
 
-  upload:
-    name: Publish Release
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Download all artifacts
-      uses: actions/download-artifact@v4
-      with:
-        path: release_files
-
-    - name: Flatten & rename
-      run: |
-        mkdir -p zips
-        mv release_files/AnyKernel3-main/AnyKernel3-main.zip zips/
-        mv release_files/AnyKernel3-ksu/AnyKernel3-ksu.zip zips/
-
-    - name: Get timestamp
-      id: time
-      run: echo "timestamp=$(date -u +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_OUTPUT
-
-    - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
-      with:
-        tag_name: latest-evergo
-        name: Evergo Kernel Build - ${{ steps.time.outputs.timestamp }}
-        body: |
-          自动构建刷机包（上传者：${{ github.actor }}）
-
-          分支构建：
-          - main
-          - ksu
-
-          时间：${{ steps.time.outputs.timestamp }}
-        files: |
-          zips/AnyKernel3-main.zip
-          zips/AnyKernel3-ksu.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Show ccache stats
+      run: ccache -s

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
     timeout-minutes: 45
     env:
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_MAXSIZE: 20G
       ARCH: arm64
       SUBARCH: arm
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 20G
 
     steps:
     - name: Checkout branch
@@ -25,20 +25,24 @@ jobs:
       with:
         ref: ${{ matrix.branch }}
 
-    - name: Install dependencies & toolchain
+    - name: Install Dependencies & Toolchain
       run: |
         sudo apt update
-        sudo apt install -y build-essential clang lld libssl-dev libelf-dev flex bison bc ccache curl git git-lfs gnupg gperf imagemagick liblz4-tool libncurses6 libncurses5-dev libsdl1.2-dev libxml2 libxml2-utils lzop pngcrush rsync schedtool squashfs-tools xsltproc zip zlib1g-dev gcc-aarch64-linux-gnu
+        sudo apt install -y \
+          build-essential clang lld libssl-dev libelf-dev flex bison bc ccache \
+          curl git git-lfs gnupg gperf imagemagick liblz4-tool libncurses6 \
+          libncurses5-dev libsdl1.2-dev libxml2 libxml2-utils lzop pngcrush rsync \
+          schedtool squashfs-tools xsltproc zip zlib1g-dev gcc-aarch64-linux-gnu
 
     - name: Set swap to 10G
       uses: pierotofy/set-swap-space@master
       with:
         swap-size-gb: 10
 
-    - name: Configure ccache
+    - name: Setup ccache
       run: |
         mkdir -p $CCACHE_DIR
-        echo "max_size = $CCACHE_MAXSIZE"
+        echo "max_size = $CCACHE_MAXSIZE" > $CCACHE_DIR/ccache.conf
         sudo chmod -R 777 $CCACHE_DIR
 
     - name: Restore ccache
@@ -46,14 +50,16 @@ jobs:
       with:
         path: ${{ env.CCACHE_DIR }}
         key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}
+        restore-keys: |
+          kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-
 
-    - name: Initialize KernelSU (only for ksu branch)
-      if: ${{ matrix.branch == 'ksu' }}
+    - name: Initialize KernelSU (if ksu)
+      if: matrix.branch == 'ksu'
       run: |
         git submodule init
         git submodule update
 
-    - name: Build kernel
+    - name: Build Kernel
       run: |
         make -j$(nproc) O=out \
           CC="ccache clang" \
@@ -63,7 +69,10 @@ jobs:
           CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
           CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
           LLVM_IAS=1 \
-          KCFLAGS="--target=aarch64-linux-gnu -Wno-unused-but-set-variable -Wno-implicit-function-declaration -Wno-unused-variable -Wno-unused-function -Wno-unused-label" \
+          KCFLAGS="--target=aarch64-linux-gnu \
+                   -Wno-unused-but-set-variable \
+                   -Wno-implicit-function-declaration \
+                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label" \
           evergo_defconfig
 
         make -j$(nproc) O=out \
@@ -74,32 +83,32 @@ jobs:
           CROSS_COMPILE_COMPAT=aarch64-linux-gnueabi- \
           CROSS_COMPILE_ARM32=arm-linux-gnueabi- \
           LLVM_IAS=1 \
-          KCFLAGS="--target=aarch64-linux-gnu -Wno-unused-but-set-variable -Wno-implicit-function-declaration -Wno-unused-variable -Wno-unused-function -Wno-unused-label"
+          KCFLAGS="--target=aarch64-linux-gnu \
+                   -Wno-unused-but-set-variable \
+                   -Wno-implicit-function-declaration \
+                   -Wno-unused-variable -Wno-unused-function -Wno-unused-label"
 
-    - name: Package kernel with AnyKernel3
+    - name: Package Kernel
       run: |
-        git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git
+        git clone --depth=1 https://github.com/osm0sis/AnyKernel3.git AnyKernel3
         cp out/arch/arm64/boot/Image.gz-dtb AnyKernel3/
 
-        # 修复 anykernel.sh 内容
-        sed -i 's/^device\.name1=.*/device.name1=evergo/' AnyKernel3/anykernel.sh
-        sed -i 's/^device\.name[2-5]=.*/device.name2=\ndevice.name3=\ndevice.name4=\ndevice.name5=/' AnyKernel3/anykernel.sh
-        sed -i 's|^BLOCK=.*omap.*|BLOCK=boot;|' AnyKernel3/anykernel.sh
+        # 替换 anykernel.sh 设备代号
+        sed -i 's/device\.name1=.*/device.name1=evergo/' AnyKernel3/anykernel.sh
+        for i in 2 3 4 5; do sed -i "s/device\.name$i=.*/device.name$i=/" AnyKernel3/anykernel.sh; done
 
-        zip -r9 AnyKernel3-${{ matrix.branch }}.zip AnyKernel3/*
+        # 替换 anykernel.sh 中 BLOCK=xxx 为 BLOCK=boot
+        sed -i 's/^BLOCK=.*/BLOCK=boot/' AnyKernel3/anykernel.sh
 
-    - name: Upload release to GitHub
-      uses: softprops/action-gh-release@v1
+        cd AnyKernel3
+        zip -r9 ../AnyKernel3-${{ matrix.branch }}.zip *
+        cd ..
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
       with:
-        tag_name: kernel-release-${{ github.run_id }}
-        name: Kernel Build - ${{ github.run_id }}
-        body: |
-          构建分支：${{ matrix.branch }}
-          上传者：${{ github.actor }}
-          构建时间：${{ github.event.head_commit.timestamp }}
-        files: AnyKernel3-${{ matrix.branch }}.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: AnyKernel3-${{ matrix.branch }}
+        path: AnyKernel3-${{ matrix.branch }}.zip
 
     - name: Save ccache
       uses: actions/cache/save@v3
@@ -107,5 +116,42 @@ jobs:
         path: ${{ env.CCACHE_DIR }}
         key: kernel-ccache-${{ runner.os }}-${{ env.ARCH }}-${{ matrix.branch }}-${{ github.run_id }}
 
-    - name: Show ccache stats
-      run: ccache -s
+  upload:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: release_files
+
+    - name: Flatten & rename
+      run: |
+        mkdir -p zips
+        mv release_files/AnyKernel3-main/AnyKernel3-main.zip zips/
+        mv release_files/AnyKernel3-ksu/AnyKernel3-ksu.zip zips/
+
+    - name: Get timestamp
+      id: time
+      run: echo "timestamp=$(date -u +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_OUTPUT
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: latest-evergo
+        name: Evergo Kernel Build - ${{ steps.time.outputs.timestamp }}
+        body: |
+          自动构建刷机包（上传者：${{ github.actor }}）
+
+          分支构建：
+          - main
+          - ksu
+
+          时间：${{ steps.time.outputs.timestamp }}
+        files: |
+          zips/AnyKernel3-main.zip
+          zips/AnyKernel3-ksu.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* ✨ **修复anykernel3的boot挂载位置错误**

  * ”BLOCK = boot“ 代替 ”BLOCK=/dev/block/platform/omap/omap_hsmmc.0/by-name/boot“

* 🧠 **自动判断是否为 KSU 分支并初始化 submodule**

* 🧹 **自动修改 `anykernel.sh` 中的设备代号为 `evergo`**

  * 保证刷机包匹配目标机型，避免误刷

* 📦 **构建完成后自动打包为刷机 ZIP**

  * 命名格式为 `AnyKernel3-main.zip` / `AnyKernel3-ksu.zip`

* 🚀 **新增独立发布 job，构建完成后统一上传两个 ZIP 到 GitHub Release**

  * Release 名称自动带上 UTC 时间戳，如 `Evergo Kernel Build - 2025-07-03_14-22-11`
  * 附带构建信息：上传者、构建时间、分支名

* 💾 **保留对 `ccache` 的支持，提升后续构建速度**